### PR TITLE
Add FreeCAD work in progress

### DIFF
--- a/birdhouse/FreeCad.py
+++ b/birdhouse/FreeCad.py
@@ -1,0 +1,140 @@
+width = 120
+extendedWidth = width*1.1
+height = 85
+thickness = 2.0
+
+def makeSketch(sketchName, plane = 'YZ_Plane', points=[], constraints=[]):
+    partName = sketchName
+    baseFrameName = sketchName
+    App.getDocument('Unnamed').getObject('Body').newObject('Sketcher::SketchObject', baseFrameName)
+    App.getDocument('Unnamed').getObject(baseFrameName).Support = (App.getDocument('Unnamed').getObject(plane),[''])
+    App.getDocument('Unnamed').getObject(baseFrameName).MapMode = 'FlatFace'
+
+    ActiveSketch = App.getDocument('Unnamed').getObject(baseFrameName)
+
+    def addLine(pointIdx1, pointIdx2):
+        point1 = ActiveSketch.Geometry[pointIdx1]
+        point2 = ActiveSketch.Geometry[pointIdx2]
+        lineIdx = ActiveSketch.addGeometry(Part.LineSegment(App.Vector(point1.X, point1.Y,0),App.Vector(point2.X,point2.Y,0)),False)
+        ActiveSketch.addConstraint(Sketcher.Constraint('Coincident',lineIdx,1,pointIdx1,1))
+        ActiveSketch.addConstraint(Sketcher.Constraint('Coincident',lineIdx,2,pointIdx2,1))
+        return lineIdx
+
+    myMap = {}
+    for index in range(len(points)):
+        xPoint = 0.5 if index == 0 else index
+        yPoint = index
+        pointIdx = ActiveSketch.addGeometry(Part.Point(App.Vector(xPoint,yPoint,0)))
+        myMap[points[index]['name']] = pointIdx
+        points[index]['index'] = pointIdx
+
+
+    lineMap = {}
+    for index in range(len(points)):
+        previousIndex = len(points) - 1 if index == 0 else index - 1
+        previousPointIndex = points[previousIndex]['index']
+        currentPointIndex = points[index]['index']
+        lineIdx = addLine(previousPointIndex, currentPointIndex)
+        previousPointName = points[previousIndex]['name']
+        currentPointName = points[index]['name']
+        lineMap["{previousPointName}-{currentPointName}".format(previousPointName=previousPointName, currentPointName=currentPointName)] = lineIdx
+
+    def findLineIndex(lineName = ""):
+        if lineName is None:
+            return None
+        nameParts = lineName.split("-")
+        alternateName = nameParts[1] + '-' + nameParts[0]
+        return lineMap.get(lineName) or lineMap.get(alternateName)
+
+    for constraint in constraints:
+        line = constraint.get('line')
+        point = constraint.get('point')
+        conType = constraint['type']
+        lineIdx = findLineIndex(line)
+        pointIdx = myMap.get(point)
+        if conType == 'Horizontal':
+            idx = ActiveSketch.addConstraint(Sketcher.Constraint('Horizontal',lineIdx))
+        elif conType == 'Distance':
+            distance = constraint['value']
+            ActiveSketch.addConstraint(Sketcher.Constraint('Distance',lineIdx,distance))
+        elif conType == 'OnXAxis':
+            ActiveSketch.addConstraint(Sketcher.Constraint('PointOnObject',lineIdx,1,-1))
+        elif conType == 'OriginXDistance':
+            xAxisIdx = -1
+            distance = constraint['value']
+            ActiveSketch.addConstraint(Sketcher.Constraint('DistanceX',pointIdx,1,xAxisIdx,1,distance))
+        elif conType == 'OnYAxis':
+            yAxisIdx = -2
+            ActiveSketch.addConstraint(Sketcher.Constraint('PointOnObject',pointIdx,1,yAxisIdx))
+        elif conType == 'perpendicularDistance':
+            distance = constraint['value']
+            ActiveSketch.addConstraint(Sketcher.Constraint('Distance',pointIdx,1,lineIdx,distance))
+
+def makeFrame(partName, plane = 'YZ_Plane'):
+    points = [
+        {
+            'name': 'baseR',
+        },
+        {
+            'name': 'baseL',
+        },
+        {
+            'name': 'top',
+        },
+    ]
+
+    constraints = [
+        {
+            'type': 'Horizontal',
+            'line': 'baseR-baseL'
+        },
+        {
+            'type': 'Distance',
+            'value': width,
+            'line': 'baseR-baseL'
+        },
+        {
+            'type': 'OnXAxis',
+            'line': 'baseR-baseL'
+        },
+        {
+            'type': 'OriginXDistance',
+            'value': width/2,
+            'point': 'baseR',
+        },
+        {
+            'type': 'OnYAxis',
+            'point': 'top',
+        },
+        {
+            'type': 'perpendicularDistance',
+            'value': height,
+            'point': 'top',
+            'line': 'baseR-baseL'
+        },
+    ]
+    baseFrameName = "{partName}_BaseFrameName".format(partName=partName)
+    makeSketch(baseFrameName, plane, points, constraints)
+
+    baseFrameOffset = "{partName}_BaseFrameOffset".format(partName=partName)
+    App.ActiveDocument.addObject("Part::Offset2D",baseFrameOffset)
+    currentOffset = App.getDocument('Unnamed').getObject(baseFrameOffset)
+    currentOffset.Source = App.getDocument('Unnamed').getObject(baseFrameName)
+    currentOffset.Value = thickness
+    currentOffset.Fill = True
+
+    baseFrameSolid = "{partName}_BaseFrameSolid".format(partName=partName)
+    App.getDocument('Unnamed').addObject('Part::Extrusion',baseFrameSolid)
+    f = App.getDocument('Unnamed').getObject(baseFrameSolid)
+    f.Base = currentOffset
+    f.DirMode = "Normal"
+    f.LengthFwd = extendedWidth
+    if plane == 'YZ_Plane':
+        f.Placement.Base = App.Vector(-extendedWidth/2,0,0)
+    else:
+        f.Placement.Base = App.Vector(0, -extendedWidth/2,0)
+
+makeFrame('initial')
+makeFrame('copy', 'XZ_Plane')
+
+App.ActiveDocument.recompute()


### PR DESCRIPTION
## experiments with making the birdhouse in a code-centric manner.

![image](https://user-images.githubusercontent.com/29681384/102872558-f8347200-4493-11eb-8a5c-e548d8e31cb8.png)

Ultimately I didn't finish the bird-house, but my goal was never to complete the birdhouse at all costs with code (because I could just copy everything from the python console for that).

Instead, the goal was to become familiar with methods/classes at play in freecad and see if I could come up with a generalised approach to make Cading in freeCAD in a code only fashion sustainable and enjoyable. So I would say I failed at doing so for the amount of the effort I'm willing to put in right now, I feel like I hit some obstacles that would be pretty hard to overcome, but that's also why I'm consulting the FreeCAD community to see if they have any killer ideas. I'm not sure to what extent code-only-cading in freecad has been explored previously. Maybe I've gone about it completely wrong?

## Background
Most of the code-cad packages use CSG paradigm, that is boolean operations with 3d primitives. I think this a very limited mode that the community is stuck in (my opinion). Since FreeCad uses a constraint-based-model, with a BREP kernal, and support for a lot of customization there feels like there's an opportunity here.

One of OpenSCAD's (the OG code-cad package) greatest strengths is that its very declarative in nature. OpenSCAD code describes what the shape should look like and it's not exactly procedural. In this regard, a power extension to the code-cad paradigm would be a declarative syntax/API that incorporates constraints, and this can be done in any language just by having a data structure convention.

So in the code I had an attempt at doing so with some very basic sketches, where the sketch is made of a series of vertices that form a complete loop, and these vertices are then referenced to add constraints to the sketch. It worked for this very simple example. Look at my inline comments for further details.

These attempts at constant based code modelling is what I failed at. If I was trying to do boolean operations with 3d primitives in FreeCAD, I'm sure that would be reasonably straight forward.

### Where did it fall apart?

While I had already started to introduce some hacky things in the simple example. When I tried to add arc/radii into the mix things really feel apart. When adding curves the "tangent" constraint is very important and this is where I found FreeCAD to be less than deterministic. Mainly because whenever an arc is made to be tangential with a line there are two directions it can do so in, an obtuse (where the line flows smoothly into the arc) or acute (where it comes to a sharp point). Normally with use in the GUI this isn't a problem because FreeCAD snaps to the one it matches closes to and it has a user to guide it, but when trying to describe to tangent with code I feel like it's important to differentiate between the two. Some of the code from this experiment can be [found here](https://github.com/Irev-Dev/curated-code-cad/blob/kurt/broken-freecad-experiments/birdhouse/FreeCAD.py#L148)

Now, much of what I've been talking about might simply be the case that there are functions and methods that do all this that I'm simply not aware of. Otherwise, I also found that I would often have to draw lines arbitrarily in 2d space just so they existed before I constrained them, that's completely fine for proof of concept like this, but it did add to the general feel that I was very much trying to fit a square peg into a hole.

Oh and BTW I've been using v0.19