### PR TITLE
add manifold

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ JSCAD allows anyone to create 3D (or 2D) designs by combining simple shapes. And
 
 Libfive is a software library and set of tools for solid modelling, especially suited for parametric and procedural design. Lisp based language, (so (you (((((can expect ) lots of parentheses))))).
 
+### [manifold](https://github.com/elalish/manifold)
+- [Repo](https://github.com/elalish/manifold)
+- ~~Community~~
+- [Docs](https://manifoldcad.org/docs/html/modules.html)
+- License: Apache 2.0
+- [Online editor](https://manifoldcad.org/)
+
+Manifold is a fast and robust mesh library with support for CSG, SDF, and other miscellaneous mesh operations.
+It is currently used by OpenSCAD as an experimental backend with [huge speedup](https://github.com/openscad/openscad/pull/4533).
+It is not uncommon to see >100x speedup over the old backend of OpenSCAD.
+
+Manifold provides a C++ API as well as C, Python and JavaScript (typescript) bindings.
+Users can use its JavaScript binding with the [online editor](https://manifoldcad.org), and the result can be exported in either gltf and 3mf formats (3mf is an alternative to stl that preserves manifoldness).
+
 ### [pythonOCC](http://www.pythonocc.org/)
 - [Repo](https://github.com/tpaviot/pythonocc-core)
 - ~~Community~~

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I recommend reading through the entire list below to see if one chimes with you 
 
 - OpenSCAD is tried and true, with lots of examples and tutorials floating around the internet. It also has a very intuitive syntax that folks without prior programming experience have been able to quickly pick up. However, some reasons you might want to look elsewhere are:
   - It can be hard to build powerful abstractions since they've rolled their own language. Consequences of this include that it doesn't have a package manager like many modern languages, and the presence of quirks with the language, such as function definitions that aren't ergonomic.
-  - Performance can start to suffer with complex parts.
+  - Performance can start to suffer with complex parts. (Note that the development snapshot with experimental option 'manifold' enabled can provide a large speedup).
   - Its mesh-based kernel has limitations if you want to move beyond 3d-printed parts.
 - Check out the [birdhouse example](https://github.com/Irev-Dev/curated-code-cad/tree/main/birdhouse), while anecdotal, seeing the same part made with different tools might help you decide which syntax you like the most.
 - You might want to simply pick a tool based on your language of choice. Clojure, enaml, Go, Haskell, Lisp, Javascript and Python are all represented below.


### PR DESCRIPTION
Added entry for manifold, and also point users to use the development snapshot of OpenSCAD with manifold enabled for faster performance.

Closes #25.